### PR TITLE
Add YAML formatter and Java, FreeMarker syntax validators

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Text Formatter</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
 </head>
 <body>
     <header class="site-header">
         <div class="logo-container">
-            <a href="#" class="logo">JSON Formatter</a>
+            <a href="#" class="logo">Text Formatter</a>
         </div>
     </header>
 
@@ -19,6 +20,9 @@
         <div class="format-toggle">
             <button class="toggle-btn active" data-format="json">JSON</button>
             <button class="toggle-btn" data-format="html">HTML</button>
+            <button class="toggle-btn" data-format="yaml">YAML</button>
+            <button class="toggle-btn" data-format="java">Java</button>
+            <button class="toggle-btn" data-format="freemarker">FreeMarker</button>
         </div>
         
         <div class="editor-container">

--- a/script.js
+++ b/script.js
@@ -96,6 +96,269 @@ function addRainbowColors(json) {
     return result;
 }
 
+// Function to format YAML
+function formatYAML(yamlString) {
+    // Load the YAML string, jsyaml.load will throw an error if it's invalid
+    const parsedYaml = jsyaml.load(yamlString);
+    // Dump the JavaScript object back to a YAML string with indentation
+    return jsyaml.dump(parsedYaml, { indent: 2 });
+}
+
+// Function to validate Java syntax (basic checks)
+function validateJava(javaCode) {
+    const errors = [];
+    const lines = javaCode.split('\\n');
+
+    // 1. Balanced brackets
+    const stack = [];
+    const bracketPairs = { '(': ')', '[': ']', '{': '}' };
+    for (let i = 0; i < javaCode.length; i++) {
+        const char = javaCode[i];
+        if (bracketPairs[char]) {
+            stack.push(char);
+        } else if (Object.values(bracketPairs).includes(char)) {
+            if (stack.length === 0 || bracketPairs[stack.pop()] !== char) {
+                errors.push(`Mismatched or unexpected closing bracket: ${char}`);
+                // No need to continue checking brackets if an error is found here,
+                // as it can lead to many follow-up errors.
+                break;
+            }
+        }
+    }
+    if (stack.length > 0) {
+        errors.push(`Unclosed opening brackets: ${stack.join(', ')}`);
+    }
+
+    // 2. Semicolon checks (heuristic)
+    lines.forEach((line, index) => {
+        const trimmedLine = line.trim();
+        // Skip empty lines, comments, package/import, class/interface/enum declarations, method signatures, and lines ending with { or } or ;
+        if (trimmedLine === '' ||
+            trimmedLine.startsWith('//') ||
+            trimmedLine.startsWith('/*') ||
+            trimmedLine.endsWith('*/') ||
+            trimmedLine.startsWith('package ') ||
+            trimmedLine.startsWith('import ') ||
+            trimmedLine.match(/^(public|private|protected)?\s*(static\s+|final\s+|abstract\s+)*\s*(class|interface|enum)\s+\w+/i) || // basic class/interface/enum
+            trimmedLine.match(/\w+\s+\w+\(.*\)\s*(\{?|throws)?$/) || // basic method signature
+            trimmedLine.match(/^(if|for|while|switch)\s*\(.*\)\s*\{?$/) || // control structures
+            trimmedLine.endsWith('{') ||
+            trimmedLine.endsWith('}') ||
+            trimmedLine.endsWith(';') ||
+            trimmedLine.endsWith(',')) { // Allow lines ending with comma (e.g. enum values, array initializers)
+            return;
+        }
+        // If it's a non-empty line that doesn't fall into skips and doesn't end with ;, it might need one.
+        // This is a very rough heuristic.
+        if (trimmedLine.length > 0 && !trimmedLine.endsWith(';')) {
+            // Further refine: check if it's part of a multi-line statement
+            // For simplicity, we'll flag it if it's not obviously a block opener or comment
+            if (!trimmedLine.endsWith('{') && !trimmedLine.match(/\/\*|\*\//)) {
+                 // Check if the next non-empty line starts with typical statement continuation characters like '.', '[', or is a lambda '->'
+                let nextLineIndex = index + 1;
+                let nextNonEmptyLine = '';
+                while(nextLineIndex < lines.length) {
+                    nextNonEmptyLine = lines[nextLineIndex].trim();
+                    if (nextNonEmptyLine !== '' && !nextNonEmptyLine.startsWith('//') && !nextNonEmptyLine.startsWith('/*')) break;
+                    nextLineIndex++;
+                }
+                if (nextNonEmptyLine && (nextNonEmptyLine.startsWith('.') || nextNonEmptyLine.startsWith('[') || nextNonEmptyLine.includes('->'))) {
+                    // Likely a multi-line statement, so don't flag current line for missing semicolon
+                } else {
+                    errors.push(`Line ${index + 1} might be missing a semicolon: "...${trimmedLine.slice(-30)}"`);
+                }
+            }
+        }
+    });
+
+    // 3. Basic comma misuse
+    if (javaCode.match(/,,/)) {
+        errors.push("Found consecutive commas ',,'");
+    }
+    const linesWithTrailingCommas = [];
+    javaCode.split('\\n').forEach((line, index) => {
+        // Avoid flagging comments or lines that are part of annotations correctly using trailing commas
+        const trimmedLine = line.trim();
+        if (trimmedLine.startsWith('//') || trimmedLine.startsWith('@')) return;
+
+        if (trimmedLine.match(/,\s*(\)|}|])/)) {
+             errors.push(`Line ${index + 1}: Found comma before a closing bracket/brace: ${trimmedLine.match(/,\s*(\)|}|])/)[0]}`);
+        }
+        // A simple check for trailing comma, might be too broad for Java as some contexts allow it (e.g. array initializers last element)
+        // For now, let's be conservative and not add a general trailing comma check to avoid false positives.
+        // A more specific check could be for things like `method(arg1,);`
+        if (trimmedLine.match(/,\s*;/)) {
+            errors.push(`Line ${index + 1}: Found comma directly before a semicolon: ",;"`);
+        }
+    });
+
+
+    return {
+        isValid: errors.length === 0,
+        errors: errors
+    };
+}
+
+// Function to validate FreeMarker syntax (basic checks)
+function validateFreeMarker(ftlCode) {
+    const errors = [];
+    const tagStack = [];
+    // Simplified list of block tags that require a closing tag. Add more as needed.
+    const blockTags = ['if', 'list', 'items', 'sep', 'macro', 'function', 'attempt', 'compress', 'transform', 'escape', 'noescape', 'autoesc', 'noautoesc', 'switch', 'case', 'default'];
+    // Simplified list of self-closing tags or tags that don't need explicit stack management here
+    const selfClosingOrSpecialTags = ['assign', 'global', 'local', 'include', 'import', 'lt', 'rt', 't', 'nt', 'break', 'continue', 'stop', 'return', 'setting', 'ftl', 'else', 'elseif', 'recover', 'fallback'];
+
+    // Regex to find FTL tags/comments/interpolations
+    // This regex is complex and aims to capture various FTL constructs.
+    // 1. Comments: <#-- ... -->
+    // 2. Closing tags: </#tagName> or </@tagName>
+    // 3. Self-closing or opening tags: <#tagName ...> or <@tagName ...>
+    // 4. Interpolations: ${...} or #{...}
+    const ftlRegex = /(<#--[\s\S]*?-->)|(<\/\s*(?:#|@)\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*>)|(<(#|@)\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*([^>]*?))?\s*(\/)?>)|(\$\{[\s\S]*?\}|\#\{[\s\S]*?\})/g;
+
+    let match;
+    let lastIndex = 0;
+
+    while ((match = ftlRegex.exec(ftlCode)) !== null) {
+        const fullMatch = match[0];
+        const comment = match[1];
+        const closingTag = match[2];
+        const closingTagName = match[3];
+        const openingTag = match[4];
+        const directiveType = match[5]; // # or @
+        const openingTagName = match[6];
+        const tagAttributes = match[7] || ''; // Attributes/parameters
+        const selfClosedMarker = match[8]; // '/' for self-closing like <#tag />
+        const interpolation = match[9];
+
+        lastIndex = ftlRegex.lastIndex;
+
+        if (comment) continue; // Skip comments
+
+        if (interpolation) {
+            // Validate brackets inside interpolations: ${...} or #{...}
+            const expression = interpolation.substring(2, interpolation.length - 1);
+            const exprErrors = validateExpressionBrackets(expression, `Interpolation ${interpolation.substring(0,15)}...`);
+            errors.push(...exprErrors);
+            continue;
+        }
+
+        if (openingTag) {
+            // Validate brackets in attributes if any
+            if (tagAttributes) {
+                const attrErrors = validateExpressionBrackets(tagAttributes, `Tag <${directiveType}${openingTagName} ...> attributes`);
+                errors.push(...attrErrors);
+            }
+
+            if (selfClosedMarker || openingTagName === 'else' || openingTagName === 'elseif' || openingTagName === 'recover' || openingTagName === 'fallback' || selfClosingOrSpecialTags.includes(openingTagName)) {
+                if (openingTagName === 'elseif' || openingTagName === 'else' || openingTagName === 'recover' || openingTagName === 'fallback') {
+                    if (tagStack.length === 0) {
+                        errors.push(`Unexpected <#${openingTagName}> without a preceding opening tag.`);
+                    } else {
+                        const lastTag = tagStack[tagStack.length -1];
+                        // <#else> and <#elseif> should be within an <#if> or <#switch> (more complex for switch)
+                        // <#recover> within <#attempt>
+                        // <#fallback> within <#switch> (as a special case)
+                        if ( (openingTagName === 'else' || openingTagName === 'elseif') && !(lastTag === 'if' || lastTag === 'switch') ) {
+                             // errors.push(`Debug: <#${openingTagName}> found. Stack top: ${lastTag}`);
+                        } else if (openingTagName === 'recover' && lastTag !== 'attempt') {
+                            errors.push(`<#recover> must be inside an <#attempt> block. Found inside <#${lastTag}>.`);
+                        }
+                    }
+                }
+                // It's a self-closing tag or special handling, don't push to stack unless it's a block opener that was self-closed (which is an error)
+                if (selfClosedMarker && blockTags.includes(openingTagName)){
+                    errors.push(`Block directive <#${openingTagName}> cannot be self-closing.`);
+                }
+
+            } else if (blockTags.includes(openingTagName)) {
+                tagStack.push(openingTagName);
+            } else if (directiveType === '@') { // Custom directives might be paired or self-closing
+                 // Heuristic: if it's not known block tag and has no self-closed marker, assume it's an opening of a pair.
+                 // More robust solution would require knowing custom directive types.
+                if (!selfClosedMarker) {
+                    tagStack.push(`@${openingTagName}`);
+                }
+            }
+        } else if (closingTag) {
+            let expectedTagName = closingTagName;
+            if (directiveType === '@' && !expectedTagName.startsWith('@')) { // Ensure custom directive closing tags are checked correctly
+                expectedTagName = `@${closingTagName}`;
+            }
+
+
+            if (tagStack.length === 0) {
+                errors.push(`Unexpected closing tag: ${fullMatch}`);
+            } else {
+                const lastOpenedTag = tagStack.pop();
+                let expectedClose = lastOpenedTag;
+                if (lastOpenedTag.startsWith('@') && !closingTagName.startsWith('@')){
+                    // no-op, closing tag for custom directive does not need @
+                } else if (!lastOpenedTag.startsWith('@') && closingTagName.startsWith('@')) {
+                     errors.push(`Mismatched closing tag: Expected </#${lastOpenedTag}> but found </@${closingTagName}>`);
+                     continue;
+                }
+
+
+                if (lastOpenedTag.startsWith('@') ? `@${closingTagName}` !== lastOpenedTag : closingTagName !== lastOpenedTag) {
+                     errors.push(`Mismatched closing tag: Expected </#${lastOpenedTag.replace('@','')}> but found ${fullMatch}`);
+                }
+            }
+        }
+    }
+
+    if (tagStack.length > 0) {
+        errors.push(`Unclosed FTL tags: ${tagStack.join(', ')}`);
+    }
+
+    return {
+        isValid: errors.length === 0,
+        errors: errors
+    };
+}
+
+// Helper function to validate brackets within expressions (e.g., inside ${...} or tag attributes)
+function validateExpressionBrackets(expression, context) {
+    const errors = [];
+    const stack = [];
+    const bracketPairs = { '(': ')', '[': ']', '{': '}' }; // Allow {} for inline maps/hashes
+    let inString = false;
+    let stringChar = '';
+
+    for (let i = 0; i < expression.length; i++) {
+        const char = expression[i];
+
+        if (inString) {
+            if (char === stringChar) {
+                if (i > 0 && expression[i-1] === '\\') { // Handle escaped quotes
+                    // still in string
+                } else {
+                    inString = false;
+                }
+            }
+            continue; // Ignore brackets inside strings
+        }
+
+        if (char === '"' || char === "'") {
+            inString = true;
+            stringChar = char;
+            continue;
+        }
+
+        if (bracketPairs[char]) {
+            stack.push(char);
+        } else if (Object.values(bracketPairs).includes(char)) {
+            if (stack.length === 0 || bracketPairs[stack.pop()] !== char) {
+                errors.push(`Mismatched or unexpected closing bracket '${char}' in ${context}`);
+                break; // Stop on first error to avoid cascading issues
+            }
+        }
+    }
+    // Unclosed brackets in expressions are not checked here to avoid conflict with FTL's own error reporting for incomplete expressions
+    // For example `${user.name(` will be an FTL error anyway. This focuses on mismatches.
+    return errors;
+}
+
 
 document.getElementById('beautify').addEventListener('click', function() {
     const input = document.getElementById('input').value;
@@ -125,8 +388,40 @@ document.getElementById('beautify').addEventListener('click', function() {
             output.innerHTML = beautified;
             validationIndicator.style.display = 'block';
             validationIndicator.textContent = 'HTML is formatted!';
+        } else if (currentFormat === 'yaml') {
+            // Beautify YAML
+            const beautified = formatYAML(input); // We'll define this function
+            output.textContent = beautified; // YAML output as plain text
+            validationIndicator.style.display = 'block';
+            validationIndicator.textContent = 'YAML is valid & formatted!';
+        } else if (currentFormat === 'java') {
+            const validationResult = validateJava(input); // We'll define this function
+            if (validationResult.isValid) {
+                output.textContent = input; // Show original code
+                validationIndicator.style.display = 'block';
+                validationIndicator.textContent = 'Java syntax appears valid (basic checks).';
+            } else {
+                output.textContent = 'Java Syntax Errors Found:\n\n' + validationResult.errors.join('\n');
+                validationIndicator.style.display = 'block';
+                validationIndicator.textContent = 'Java syntax errors found!';
+                validationIndicator.style.color = 'red'; // Optional: make error more prominent
+            }
+        } else if (currentFormat === 'freemarker') {
+            const validationResult = validateFreeMarker(input); // We'll define this function
+            if (validationResult.isValid) {
+                output.textContent = input; // Show original code
+                validationIndicator.style.display = 'block';
+                validationIndicator.textContent = 'FreeMarker syntax appears valid (basic checks).';
+            } else {
+                output.textContent = 'FreeMarker Syntax Errors Found:\n\n' + validationResult.errors.join('\n');
+                validationIndicator.style.display = 'block';
+                validationIndicator.textContent = 'FreeMarker syntax errors found!';
+                validationIndicator.style.color = 'red';
+            }
         }
     } catch (e) {
+        // Reset validation indicator color if it was changed
+        validationIndicator.style.color = ''; // Or your default color
         output.textContent = `Error: ${e.message}`;
         validationIndicator.style.display = 'none';
     }


### PR DESCRIPTION
- Implemented YAML formatting using the js-yaml library.
- Added a basic syntax validator for Java code, checking for:
  - Balanced brackets ({}, [], ())
  - Heuristic semicolon placement
  - Basic comma misuse (,, ,), ,;)
- Added a basic syntax validator for FreeMarker templates, checking for:
  - Balanced FTL tags (#if, @custom, etc.)
  - Balanced brackets/parentheses in expressions and interpolations.
- Updated UI with toggle buttons for the new formats.
- Ensured output and validation messages are displayed appropriately for each type.